### PR TITLE
Fixed autoloader issue

### DIFF
--- a/bin/dredd-hooks-php
+++ b/bin/dredd-hooks-php
@@ -7,9 +7,21 @@ use Dredd\Hooks;
 ini_set('implicit_flush', 'on');
 ini_set('output_buffering', 'off');
 
-$autoloadPath = (in_array("vendor/bin/dredd-hooks-php", $argv) || in_array("bin/dredd-hooks-php", $argv)) ? __DIR__ . "/../../../autoload.php" : __DIR__ . "/../vendor/autoload.php";
-
-require $autoloadPath;
+$loaded = false;
+foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php'] as $file) {
+    if (file_exists($file)) {
+        require $file;
+        $loaded = true;
+        break;
+    }
+}
+if (!$loaded) {
+    die(
+        'You need to set up the project dependencies using the following commands:' . PHP_EOL .
+        'wget http://getcomposer.org/composer.phar' . PHP_EOL .
+        'php composer.phar install' . PHP_EOL
+    );
+}
 
 Hooks::loadHooks($argv);
 


### PR DESCRIPTION
The existing code didn't work for me. While running Dredd I always encountered error on 'require' line.
It may be connected with behaviour of Composer when it creates proxy shell script instead of symlink to bin file (in my case it was Vagrant folder synced with Windows host).
Anyway, watching at input parameter is not an elegant way of deciding where to look for autoloader. The solution I suggest is more common (I've borrowed it from here: https://github.com/deployphp/deployer/blob/master/bin/dep)
