### PR TITLE
New protagonist needs C++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
+sudo: required
+dist: trusty
 language: php
 before_install:
   - npm install -g dredd
   - bundle install
   - composer install
-
 php:
   - "5.4"
   - "5.5"
   - "5.6"
   - "7"
-
 script:
   - vendor/bin/phpcs --standard=psr2 -n src/
   - vendor/bin/phpunit    


### PR DESCRIPTION
To be able to install newer Dredd, one will need a C++ compiler able to compile C++11. In the future we will eventually migrate to js-only parser by default and no compiler will be needed, but as of now, this change is needed in order to make Dredd work with Travis CI.

https://github.com/apiaryio/protagonist/blob/master/CHANGELOG.md#breaking

We had the same problem at:
- https://github.com/apiaryio/dredd-hooks-python/
- https://github.com/apiaryio/dredd-hooks-ruby/

Exactly the same change fixed the builds.
