### PR TITLE
Use data objects that are documented for the transaction object.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,4 @@ RUN apt-get update \
     && wget https://getcomposer.org/installer \
     && chmod +x installer \
     && php installer --install-dir=/usr/local/bin/ --filename=composer \
+    && npm install -g dredd --no-optional

--- a/features/failing_transaction.feature
+++ b/features/failing_transaction.feature
@@ -26,7 +26,7 @@ Feature: Failing a transaction
           flush();
       });
       """
-    When I run `dredd ./apiary.apib http://localhost:4567 --server "nodejs server.js" --language php --hookfiles failedhook.php --loglevel debug`
+    When I run `dredd ./apiary.apib http://localhost:4567 --server "node server.js" --language php --hookfiles failedhook.php --loglevel debug`
     Then the exit status should be 1
     And the output should contain:
       """

--- a/features/transaction_object.feature
+++ b/features/transaction_object.feature
@@ -1,0 +1,32 @@
+Feature: Failing a transaction
+
+  Background:
+    Given I have dredd-hooks-php installed
+    Given I have Dredd installed
+    And a file named "apiary.apib" with:
+      """
+      # My Api
+      ## GET /message
+      + Response 200 (text/html)
+      """
+    And a file "server.js" with a server responding on "http://localhost:4567/message" with "Hello World!"
+
+  @announce
+  Scenario:
+    Given a file named "hook_transaction_object.php" with:
+      """
+      <?php
+
+      use Dredd\DataObjects\Transaction;
+      use Dredd\Hooks;
+
+      Hooks::beforeEach(function(Transaction &$transaction) {
+
+          echo 'Transaction object';
+      });
+      """
+    When I run `dredd ./apiary.apib http://localhost:4567 --server "node server.js" --language php --hookfiles hook_transaction_object.php --loglevel debug`
+    Then the output should contain:
+      """
+      Transaction object
+      """

--- a/hooks/hook_transaction_object.php
+++ b/hooks/hook_transaction_object.php
@@ -1,0 +1,9 @@
+<?php
+
+use Dredd\DataObjects\Transaction;
+use Dredd\Hooks;
+
+Hooks::beforeEach(function(Transaction &$transaction) {
+
+    echo 'Transaction object';
+});

--- a/src/DataObjects/ExpectedResponse.php
+++ b/src/DataObjects/ExpectedResponse.php
@@ -10,7 +10,7 @@ class ExpectedResponse
     /**
      * Keys are HTTP header names, values are HTTP header contents
      *
-     * @var object
+     * @var array<string,string>
      */
     public $headers;
 
@@ -27,7 +27,7 @@ class ExpectedResponse
     public function __construct($expected)
     {
         $this->statusCode = $expected->statusCode;
-        $this->headers = $expected->headers;
+        $this->headers = (array) $expected->headers;
         $this->body = $expected->body;
         $this->bodySchema = $expected->bodySchema;
     }

--- a/src/DataObjects/ExpectedResponse.php
+++ b/src/DataObjects/ExpectedResponse.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Dredd\DataObjects;
+
+class ExpectedResponse
+{
+    /** @var string $statusCode */
+    public $statusCode;
+
+    /**
+     * Keys are HTTP header names, values are HTTP header contents
+     *
+     * @var object
+     */
+    public $headers;
+
+    /** @var string $body */
+    public $body;
+
+    /**
+     * JSON Schema of the response body
+     *
+     * @var object $bodySchema
+     */
+    public $bodySchema;
+
+    public function __construct($expected)
+    {
+        $this->statusCode = $expected->statusCode;
+        $this->headers = $expected->headers;
+        $this->body = $expected->body;
+        $this->bodySchema = $expected->bodySchema;
+    }
+}

--- a/src/DataObjects/Origin.php
+++ b/src/DataObjects/Origin.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Dredd\DataObjects;
+
+/**
+ * Reference to the transaction definition in the original API description document.
+ * (See also {@link https://github.com/apiaryio/dredd-transactions#user-content-data-structures Dredd Transactions})
+ */
+class Origin
+{
+    /** @var string $filename */
+    public $filename;
+
+    /** @var string $apiName */
+    public $apiName;
+
+    /** @var string $resourceGroupName */
+    public $resourceGroupName;
+
+    /** @var string $resourceName */
+    public $resourceName;
+
+    /** @var string $actionName */
+    public $actionName;
+
+    /** @var string $exampleName */
+    public $exampleName;
+
+    public function __construct($origin)
+    {
+        $this->filename = $origin->filename;
+        $this->apiName = $origin->apiName;
+        $this->resourceGroupName = $origin->resourceGroupName;
+        $this->resourceName = $origin->resourceName;
+        $this->actionName = $origin->actionName;
+        $this->exampleName = $origin->exampleName;
+    }
+}

--- a/src/DataObjects/RealResponse.php
+++ b/src/DataObjects/RealResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Dredd\DataObjects;
+
+class RealResponse
+{
+    /** @var string $statusCode */
+    public $statusCode;
+
+    /**
+     * Keys are HTTP header names, values are HTTP header contents
+     *
+     * @var object
+     */
+    public $headers;
+
+    /** @var string $body */
+    public $body;
+
+    /**
+     *  - `utf-8` (string) - indicates `body` contains a textual content encoded in UTF-8
+     *  - `base64` (string) - indicates `body` contains a binary content encoded in Base64
+     *
+     * @var string $bodyEncoding
+     * @psalm-var 'utf-8'|'base64' $bodyEncoding
+     */
+    public $bodyEncoding;
+
+    public function __construct($expected)
+    {
+        $this->statusCode = $expected->statusCode;
+        $this->headers = $expected->headers;
+        $this->body = $expected->body;
+        $this->bodyEncoding = $expected->bodyEncoding;
+    }
+}

--- a/src/DataObjects/Request.php
+++ b/src/DataObjects/Request.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Dredd\DataObjects;
+
+class Request
+{
+    /** @var string $body */
+    public $body;
+
+    /**
+     * Can be manually set in {@link https://dredd.org/en/latest/hooks/index.html#hooks hooks}
+     *  - `utf-8` (string) - indicates `body` contains a textual content encoded in UTF-8
+     *  - `base64` (string) - indicates `body` contains a binary content encoded in Base64
+     *
+     * @var string $bodyEncoding
+     * @psalm-var 'utf-8'|'base64' $bodyEncoding
+     */
+    public $bodyEncoding;
+
+    /**
+     * Keys are HTTP header names, values are HTTP header contents
+     * @var object $headers
+     */
+    public $headers;
+
+    /**
+     * Request URI as it was written in API description
+     *
+     * @var string $uri
+     */
+    public $uri;
+
+    /** @var string $method */
+    public $method;
+
+    public function __construct($request)
+    {
+        $this->body = $request->body;
+        $this->bodyEncoding = $request->bodyEncoding;
+        $this->headers = $request->headers;
+        $this->uri = $request->uri;
+        $this->method = $request->method;
+    }
+}

--- a/src/DataObjects/Request.php
+++ b/src/DataObjects/Request.php
@@ -19,7 +19,7 @@ class Request
 
     /**
      * Keys are HTTP header names, values are HTTP header contents
-     * @var object $headers
+     * @var array<string,string> $headers
      */
     public $headers;
 
@@ -37,7 +37,7 @@ class Request
     {
         $this->body = $request->body;
         $this->bodyEncoding = $request->bodyEncoding;
-        $this->headers = $request->headers;
+        $this->headers = (array) $request->headers;
         $this->uri = $request->uri;
         $this->method = $request->method;
     }

--- a/src/DataObjects/Transaction.php
+++ b/src/DataObjects/Transaction.php
@@ -2,6 +2,8 @@
 
 namespace Dredd\DataObjects;
 
+use stdClass;
+
 /**
  * Transaction object is passed as a first argument to
  *  {@link https://dredd.org/en/latest/hooks/index.html#hooks hook functions}
@@ -104,8 +106,10 @@ class Transaction
         $this->port = $transaction->port;
         $this->protocol = $transaction->protocol;
         $this->fullPath = $transaction->fullPath;
-        $this->skip = $transaction->skip;
-        $this->fail = $transaction->fail;
+        $this->skip = $transaction->skip ?? false;
+        $this->fail = $transaction->fail ?? false;
+        $this->errors = $transaction->errors ?? new stdClass();
+        $this->results = $transaction->results ?? new stdClass();
         $this->origin = new Origin($transaction->origin);
         $this->request = new Request($transaction->request);
         $this->expected = new ExpectedResponse($transaction->expected);

--- a/src/DataObjects/Transaction.php
+++ b/src/DataObjects/Transaction.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Dredd\DataObjects;
+
+/**
+ * Transaction object is passed as a first argument to
+ *  {@link https://dredd.org/en/latest/hooks/index.html#hooks hook functions}
+ *  and is one of the main public interfaces in Dredd.
+ *
+ * @link https://dredd.org/en/latest/data-structures.html#transaction-object
+ */
+class Transaction
+{
+    /** @var string $id */
+    public $id;
+
+    /**
+     * Reference to the transaction definition in the original API description document
+     * (See also {@link https://github.com/apiaryio/dredd-transactions#user-content-data-structures Dredd Transactions})
+     *
+     * @var string $name
+     */
+    public $name;
+
+    /** @var string $host */
+    public $host;
+
+    /** @var int $port */
+    public $port;
+
+    /** @var string $protocol */
+    public $protocol;
+
+    /**
+     * Expanded URI Template with parameters (if any) used for the HTTP request Dredd performs to the tested server
+     *
+     * @link https://tools.ietf.org/html/rfc6570.html
+     * @var string $fullPath
+     */
+    public $fullPath;
+
+    /**
+     * Can be set to `true` and the transaction will be skipped
+     *
+     * @var bool $skip
+     */
+    public $skip;
+
+    /**
+     * Can be set to `true` or string and the transaction will fail
+     *  - (string) - failure message with details why the transaction failed
+     *  - (boolean)
+     * @var bool|string $fail
+     */
+    public $fail;
+
+    /** @var Origin $origin */
+    public $origin;
+
+    /**
+     * Test data passed to Dredd’s reporters
+     *
+     * @link https://dredd.org/en/latest/data-structures.html#transaction-test
+     * @var object
+     */
+    public $test;
+
+    /**
+     * Transaction runtime errors
+     *
+     * Whenever an exception occurs during a test run it’s being recorded under the errors property of the test.
+     *
+     * @link https://dredd.org/en/latest/data-structures.html#test-runtime-error
+     * @var object
+     */
+    public $errors;
+
+    /**
+     * Transaction result equals to the result of the
+     *  {@link https://github.com/apiaryio/gavel.js Gavel} validation library.
+     *
+     * @link https://dredd.org/en/latest/data-structures.html#transaction-results
+     * @var object
+     */
+    public $results;
+
+    /**
+     * The HTTP request Dredd performs to the tested server, taken from the API description
+     * @var Request $request
+     */
+    public $request;
+
+    /** @var ExpectedResponse $expected */
+    public $expected;
+
+    /** @var RealResponse $real */
+    public $real;
+
+    public function __construct($transaction)
+    {
+        $this->id = $transaction->id;
+        $this->name = $transaction->name;
+        $this->host = $transaction->host;
+        $this->port = $transaction->port;
+        $this->protocol = $transaction->protocol;
+        $this->fullPath = $transaction->fullPath;
+        $this->skip = $transaction->skip;
+        $this->fail = $transaction->fail;
+        $this->origin = new Origin($transaction->origin);
+        $this->request = new Request($transaction->request);
+        $this->expected = new ExpectedResponse($transaction->expected);
+        $this->real = new RealResponse($transaction->real);
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -1,6 +1,7 @@
 <?php namespace Dredd;
 
 use UnexpectedValueException;
+use Dredd\DataObjects\Transaction;
 
 class Server
 {
@@ -69,7 +70,7 @@ class Server
     public function processMessage($message, $client)
     {
         $event = $message->event;
-        $data = $message->data;
+        $data = new Transaction($message->data);
         $uuid = $message->uuid;
 
         if ($event == "beforeEach") {

--- a/tests/DreddHooksTest.php
+++ b/tests/DreddHooksTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Dredd\DataObjects\Transaction;
 use Dredd\Hooks;
 use PHPUnit\Framework\TestCase;
 
@@ -116,5 +117,50 @@ class DreddHooksTest extends TestCase
         $hooks = Hooks::getCallbacksForName('beforeHooks', $transaction);
         $this->assertCount(1, $hooks);
         $this->assertTrue(is_a($hooks[0], $this->className), sprintf("Expected %s received %s", $this->className, get_class($hooks[0])));
+    }
+
+    public function it_can_pass_a_transaction_object()
+    {
+        $transaction = new Transaction((object)[
+            'id' => 'test',
+            'name' => 'test',
+            'host' => '127.0.0.1',
+            'port' => '12345',
+            'protocol' => 'http',
+            'fullPath' => 'http://127.0.0.1:12345/path',
+            'request' => [
+                'body' => '{}',
+                'bodyEncoding' => 'utf8',
+                'headers' => [],
+                'uri' => 'http://127.0.0.1:12345/path',
+                'method' => 'GET',
+            ],
+            'origin' => [
+                'filename' => 'test.apib',
+                'apiName' => 'test',
+                'resourceGroupName' => '',
+                'resourceName' => '',
+                'actionName' => '',
+                'exampleName' => '',
+            ],
+            'expected' => [
+                'statusCode' => 200,
+                'headers' => [],
+                'body' => '{}',
+                'bodySchema' => new stdClass(),
+            ],
+            'real' => [
+                'statusCode' => 200,
+                'headers' => [],
+                'body' => '{}',
+                'bodyEncoding' => 'utf8',
+            ],
+        ]);
+
+        Hooks::before('Admin > *', function(&$transaction) {
+            $this->assertInstanceOf(Transaction::class, $transaction);
+        });
+
+        $hooks = Hooks::getCallbacksForName('beforeHooks', $transaction);
     }
 }

--- a/tests/DreddRunnerTest.php
+++ b/tests/DreddRunnerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-
+use Dredd\DataObjects\Transaction;
 use Dredd\Hooks;
 use PHPUnit\Framework\TestCase;
 
@@ -130,7 +130,7 @@ class DreddRunnerTest extends TestCase
     {
         $transactionName = 'transaction';
 
-        $transaction = new stdClass();
+        $transaction = new Transaction(new stdClass());
         $transaction->name = $transactionName;
 
         Hooks::before($transactionName, function($transaction) {
@@ -149,7 +149,7 @@ class DreddRunnerTest extends TestCase
     {
         $transactionName = 'transaction';
 
-        $transaction = new stdClass();
+        $transaction = new Transaction(new stdClass());
         $transaction->name = $transactionName;
 
         Hooks::beforeEach(function($transaction) {
@@ -168,11 +168,11 @@ class DreddRunnerTest extends TestCase
     {
         $transactionName = 'transaction';
 
-        $transaction = new stdClass();
+        $transaction = new Transaction(new stdClass());
         $transaction->name = $transactionName;
         $transaction->fail = false;
 
-        Hooks::before($transactionName, function(&$transaction) {
+        Hooks::before($transactionName, function(Transaction &$transaction) {
             $transaction->fail = true;
         });
 
@@ -191,11 +191,11 @@ class DreddRunnerTest extends TestCase
     {
         $transactionName = 'transaction';
 
-        $transaction = new stdClass();
+        $transaction = new Transaction(new stdClass());
         $transaction->name = $transactionName;
         $transaction->fail = false;
 
-        Hooks::beforeEach(function(&$transaction) {
+        Hooks::beforeEach(function(Transaction &$transaction) {
             $transaction->fail = true;
         });
 
@@ -214,10 +214,10 @@ class DreddRunnerTest extends TestCase
         $transactionName  = 'Admin > admin logs in';
         $wildcardName = 'Admin > *';
 
-        $transaction = new stdClass();
+        $transaction = new Transaction(new stdClass());
         $transaction->name = $transactionName;
 
-        Hooks::before($wildcardName, function(&$transaction)
+        Hooks::before($wildcardName, function(Transaction &$transaction)
         {
             echo 'yay this is also called';
         });
@@ -234,11 +234,11 @@ class DreddRunnerTest extends TestCase
     {
         $wildcardName     = 'Admin > admin logs in > *';
 
-        $transaction = new stdClass();
+        $transaction = new Transaction(new stdClass());
         $transactionName  = 'Admin > admin logs in > another event';
         $transaction->name = $transactionName;
 
-        Hooks::before($wildcardName, function(&$transaction)
+        Hooks::before($wildcardName, function(Transaction &$transaction)
         {
             echo 'yay this is also called';
         });

--- a/tests/DreddRunnerTest.php
+++ b/tests/DreddRunnerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Dredd\DataObjects\Transaction;
+
 use Dredd\Hooks;
 use PHPUnit\Framework\TestCase;
 
@@ -130,7 +130,7 @@ class DreddRunnerTest extends TestCase
     {
         $transactionName = 'transaction';
 
-        $transaction = new Transaction(new stdClass());
+        $transaction = new stdClass();
         $transaction->name = $transactionName;
 
         Hooks::before($transactionName, function($transaction) {
@@ -149,7 +149,7 @@ class DreddRunnerTest extends TestCase
     {
         $transactionName = 'transaction';
 
-        $transaction = new Transaction(new stdClass());
+        $transaction = new stdClass();
         $transaction->name = $transactionName;
 
         Hooks::beforeEach(function($transaction) {
@@ -168,11 +168,11 @@ class DreddRunnerTest extends TestCase
     {
         $transactionName = 'transaction';
 
-        $transaction = new Transaction(new stdClass());
+        $transaction = new stdClass();
         $transaction->name = $transactionName;
         $transaction->fail = false;
 
-        Hooks::before($transactionName, function(Transaction &$transaction) {
+        Hooks::before($transactionName, function(&$transaction) {
             $transaction->fail = true;
         });
 
@@ -191,11 +191,11 @@ class DreddRunnerTest extends TestCase
     {
         $transactionName = 'transaction';
 
-        $transaction = new Transaction(new stdClass());
+        $transaction = new stdClass();
         $transaction->name = $transactionName;
         $transaction->fail = false;
 
-        Hooks::beforeEach(function(Transaction &$transaction) {
+        Hooks::beforeEach(function(&$transaction) {
             $transaction->fail = true;
         });
 
@@ -214,10 +214,10 @@ class DreddRunnerTest extends TestCase
         $transactionName  = 'Admin > admin logs in';
         $wildcardName = 'Admin > *';
 
-        $transaction = new Transaction(new stdClass());
+        $transaction = new stdClass();
         $transaction->name = $transactionName;
 
-        Hooks::before($wildcardName, function(Transaction &$transaction)
+        Hooks::before($wildcardName, function(&$transaction)
         {
             echo 'yay this is also called';
         });
@@ -234,11 +234,11 @@ class DreddRunnerTest extends TestCase
     {
         $wildcardName     = 'Admin > admin logs in > *';
 
-        $transaction = new Transaction(new stdClass());
+        $transaction = new stdClass();
         $transactionName  = 'Admin > admin logs in > another event';
         $transaction->name = $transactionName;
 
-        Hooks::before($wildcardName, function(Transaction &$transaction)
+        Hooks::before($wildcardName, function(&$transaction)
         {
             echo 'yay this is also called';
         });


### PR DESCRIPTION
When writing hooks, I noticed it was hard to figure out what I could modify and what I had access to, without digging through the Dredd docs.

While you can't get everything (you don't know what the body looks like, or what headers exist, for example), it helps a lot to have some static analyzability and documentation in editor.

This doesn't change any behaviour in the hooks, it just allows hooks to be read as documented objects.

This will mean, if you do `$transaction->` in PHPStorm or VSCode, you can see what values (and types) exist on the transaction object from in your editor.

This should be backwards compatible as well, since, the internal data structure hasn't changed.

All values are public properties, so that json_serialize can still read them, and so that they are accessed the same way.

Now, when writing hooks, if you write:

```php
<?php

use Dredd\Hooks;
use Dredd\DataObjects\Transaction;

Hooks::afterEach(function(Transaction &$transaction) {

});
```

You will now have full readability.